### PR TITLE
Update deployment command to use gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ RUN pip install -r requirements.txt
 # Exposer le port utilisé par Flask
 EXPOSE 5000
 
-# Commande de lancement de l'app Flask (Railway détecte ce CMD)
-CMD ["python", "app.py"]
+# Commande de lancement de l'app via Gunicorn
+CMD gunicorn -b 0.0.0.0:$PORT app:app

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python app.py
+web: gunicorn -b 0.0.0.0:$PORT app:app


### PR DESCRIPTION
## Summary
- ensure OCR packages are installed
- run the Flask app with gunicorn instead of `python app.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68405f8d158083249f35531f14fd318d