### PR TITLE
Use CPU count for gunicorn workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -b 0.0.0.0:$PORT app:app
+web: gunicorn -b 0.0.0.0:$PORT --workers $(nproc) app:app


### PR DESCRIPTION
## Summary
- run gunicorn with `--workers $(nproc)` to scale with available CPUs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840602cdae4832482e66a8eb151df98