### PR TITLE
Implement temp file cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ l'application pour générer les textes.
 
 Pour un test local sans Docker, exécutez simplement la commande ci‑dessus
 après avoir installé les dépendances et défini la variable `GROQ_API_KEY`.
+
+## Fichiers temporaires
+
+Les documents générés (PDF et DOCX) sont stockés dans le dossier `tmp/`. Lorsqu’un utilisateur télécharge un fichier via l’interface, celui-ci est aussitôt supprimé du dossier afin d’éviter son accumulation. Vous pouvez supprimer manuellement le reste du contenu de `tmp/` si nécessaire.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, send_file 
+from flask import Flask, render_template, request, send_file, after_this_request
 from jinja2 import Template
 import pdfkit
 import os
@@ -513,6 +513,15 @@ def download_file(filename):
     full_path = os.path.join(TMP_DIR, os.path.basename(filename))
     if not os.path.exists(full_path):
         return "Fichier introuvable", 404
+
+    @after_this_request
+    def remove_file(response):
+        try:
+            os.remove(full_path)
+        except Exception as e:
+            app.logger.error(f"Erreur suppression fichier temporaire: {e}")
+        return response
+
     return send_file(full_path, as_attachment=True)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove downloaded temp files automatically
- document automatic deletion in README

## Testing
- `python -m py_compile ai_groq.py extract_offer.py doc_gen.py utils_extract.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6840621a5ec0832483f08b3e11bf8e53