### PR TITLE
Add dynamic sample generation in tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pdf2image==1.17.0
 pytesseract==0.3.13
 beautifulsoup4==4.13.4
 jinja2==3.1.6
+reportlab==4.4.1

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,32 @@
+import os
+import tempfile
+from utils_extract import extract_text_from_pdf, extract_text_from_docx
+from reportlab.pdfgen import canvas
+from docx import Document
+
+
+def create_pdf(path, text):
+    c = canvas.Canvas(path)
+    c.drawString(100, 750, text)
+    c.save()
+
+
+def create_docx(path, text):
+    doc = Document()
+    doc.add_paragraph(text)
+    doc.save(path)
+
+
+def test_extract_functions():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pdf_path = os.path.join(tmpdir, "sample.pdf")
+        docx_path = os.path.join(tmpdir, "sample.docx")
+
+        create_pdf(pdf_path, "Sample PDF text")
+        create_docx(docx_path, "Sample DOCX text")
+
+        pdf_text = extract_text_from_pdf(pdf_path)
+        docx_text = extract_text_from_docx(docx_path)
+
+        assert "Sample PDF text" in pdf_text
+        assert "Sample DOCX text" in docx_text


### PR DESCRIPTION
## Summary
- add a simple pytest for text extraction
- generate PDF and DOCX samples on the fly
- include reportlab dependency

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest reportlab`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406624c554832496d31bf1a4317d25