### PR TITLE
Handle missing Groq key more gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ après avoir installé les dépendances et défini la variable `GROQ_API_KEY`.
 ## Fichiers temporaires
 
 Les documents générés (PDF et DOCX) sont stockés dans le dossier `tmp/`. Lorsqu’un utilisateur télécharge un fichier via l’interface, celui-ci est aussitôt supprimé du dossier afin d’éviter son accumulation. Vous pouvez supprimer manuellement le reste du contenu de `tmp/` si nécessaire.
+
+## Tests
+
+Les tests unitaires fournis n'utilisent pas l'API Groq. Ils peuvent donc être lancés sans définir la variable `GROQ_API_KEY` :
+
+```bash
+pytest
+```

--- a/ai_groq.py
+++ b/ai_groq.py
@@ -9,16 +9,18 @@ logging.basicConfig(level=logging.DEBUG,
 logger = logging.getLogger(__name__)
 
 GROQ_API_KEY = os.environ.get("GROQ_API_KEY")
-if not GROQ_API_KEY:
-    raise RuntimeError("GROQ_API_KEY non défini dans les variables d'environnement !")
 
 GROQ_MODEL = "meta-llama/llama-4-scout-17b-16e-instruct"
 
 def ask_groq(prompt):
+    api_key = os.environ.get("GROQ_API_KEY") or GROQ_API_KEY
+    if not api_key:
+        raise RuntimeError("GROQ_API_KEY doit être défini pour appeler ask_groq")
+
     url = "https://api.groq.com/openai/v1/chat/completions"
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {GROQ_API_KEY}"
+        "Authorization": f"Bearer {api_key}"
     }
     data = {
         "model": GROQ_MODEL,


### PR DESCRIPTION
## Summary
- move GROQ_API_KEY validation into `ask_groq`
- document how to run tests without the API key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684067bf0ba0832496042e3fd2afaa63