### PR TITLE
Handle missing OCR deps in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ Les tests unitaires fournis n'utilisent pas l'API Groq. Ils peuvent donc être l
 ```bash
 pytest
 ```
+
+Les tests concernant l'extraction de texte utilisent `pytesseract` et `pdf2image`. Pour exécuter l'intégralité de la suite, assurez-vous que les dépendances système suivantes sont installées :
+
+```bash
+sudo apt-get install poppler-utils tesseract-ocr
+```

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,5 +1,11 @@
 import os
 import tempfile
+import pytest
+
+# Skip tests if optional OCR dependencies are missing
+pytest.importorskip("pytesseract")
+pytest.importorskip("pdf2image")
+
 from utils_extract import extract_text_from_pdf, extract_text_from_docx
 from reportlab.pdfgen import canvas
 from docx import Document


### PR DESCRIPTION
## Summary
- skip OCR extraction tests when `pytesseract` or `pdf2image` are unavailable
- document required system packages for running the full test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840686a4134832481ae453295ff5f66