### PR TITLE
Handle private IPs in URL extraction

### DIFF
--- a/extract_offer.py
+++ b/extract_offer.py
@@ -1,11 +1,29 @@
 import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse
+import socket
+import ipaddress
 
 def extract_text_from_url(url):
     parsed = urlparse(url)
     if not (parsed.scheme in ['http', 'https'] and parsed.netloc):
         return "[Erreur : L’URL fournie n’est pas valide.]"
+    hostname = parsed.hostname
+    try:
+        ip = socket.gethostbyname(hostname)
+        ip_obj = ipaddress.ip_address(ip)
+        if (
+            ip_obj.is_private
+            or ip_obj.is_loopback
+            or ip_obj.is_multicast
+            or ip_obj.is_reserved
+            or ip_obj.is_link_local
+            or ip_obj.is_unspecified
+        ):
+            return "[Erreur : URL non autorisée.]"
+    except Exception as e:
+        return f"[Erreur lors de la résolution DNS : {e}]"
+
     try:
         headers = {
             "User-Agent": "Mozilla/5.0 (compatible; OfferScraper/1.0; +https://tonsite.com)"

--- a/tests/test_extract_offer.py
+++ b/tests/test_extract_offer.py
@@ -1,0 +1,17 @@
+import pytest
+from extract_offer import extract_text_from_url
+
+
+def test_public_url():
+    text = extract_text_from_url('https://example.com')
+    assert not text.startswith('[Erreur')
+    assert 'Example Domain' in text
+
+@pytest.mark.parametrize('url', [
+    'http://127.0.0.1',
+    'http://10.0.0.1',
+    'http://localhost',
+])
+def test_private_url_blocked(url):
+    text = extract_text_from_url(url)
+    assert text.startswith('[Erreur')


### PR DESCRIPTION
## Summary
- validate host IPs in `extract_offer.extract_text_from_url`
- add tests to ensure private IPs are rejected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406a3c9188832487b356c181f5f234