### PR TITLE
Add tests for HTML extraction and JSON parsing

### DIFF
--- a/tests/test_ai_groq.py
+++ b/tests/test_ai_groq.py
@@ -1,0 +1,16 @@
+import pytest
+
+from ai_groq import extract_first_json
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Some text ```json\n{\"a\": 1}\n``` end", {"a": 1}),
+        ("```{\"b\": 2}```", {"b": 2}),
+        ("random {\"c\": 3} text", {"c": 3}),
+        ("no json here", None),
+    ],
+)
+def test_extract_first_json(text, expected):
+    assert extract_first_json(text) == expected

--- a/tests/test_extract_offer.py
+++ b/tests/test_extract_offer.py
@@ -1,4 +1,9 @@
 import pytest
+import threading
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from functools import partial
+import socket
+
 from extract_offer import extract_text_from_url
 
 
@@ -11,7 +16,45 @@ def test_public_url():
     'http://127.0.0.1',
     'http://10.0.0.1',
     'http://localhost',
+    'http://192.168.1.1',
+    'http://172.16.0.1',
+    'http://[::1]',
 ])
 def test_private_url_blocked(url):
     text = extract_text_from_url(url)
     assert text.startswith('[Erreur')
+
+
+def _run_test_server(directory):
+    handler = partial(SimpleHTTPRequestHandler, directory=directory)
+    server = HTTPServer(('localhost', 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def test_local_html_extraction(tmp_path, monkeypatch):
+    html = '<html><body><p>' + ('Hello ' * 40) + '</p></body></html>'
+    (tmp_path / 'index.html').write_text(html)
+
+    server = _run_test_server(tmp_path)
+    url = f'http://localhost:{server.server_address[1]}/index.html'
+
+    monkeypatch.setattr(socket, 'gethostbyname', lambda host: '93.184.216.34')
+    try:
+        text = extract_text_from_url(url)
+    finally:
+        server.shutdown()
+
+    assert not text.startswith('[Erreur')
+    assert 'Hello' in text
+
+
+@pytest.mark.parametrize('url', [
+    'notaurl',
+    'ftp://example.com',
+    'file:///tmp/test.html',
+])
+def test_invalid_url(url):
+    text = extract_text_from_url(url)
+    assert text == "[Erreur : L’URL fournie n’est pas valide.]"


### PR DESCRIPTION
## Summary
- test `extract_text_from_url` on a local HTTP server
- extend SSRF protection tests and add invalid URL cases
- test `extract_first_json` parsing utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406bc79c78832492569f0f5c97673d