### PR TITLE
Improve CV template styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, request, send_file, after_this_request
+from pathlib import Path
 from jinja2 import Template
 import pdfkit
 import os
@@ -369,9 +370,13 @@ def index():
         fiche_pdf_path = os.path.join(TMP_DIR, f"{file_id}_fiche.pdf")
         fiche_docx_path = os.path.join(TMP_DIR, f"{file_id}_fiche.docx")
         # --- HTML rendering
+        css_path = f"file://{Path('static/cv_theme.css').resolve()}"
         with open("templates/cv_template.html", encoding="utf-8") as f:
             cv_html = Template(f.read()).render(
-                cv=cv_adapte, infos_perso=infos_perso, **infos_perso
+                cv=cv_adapte,
+                infos_perso=infos_perso,
+                css_path=css_path,
+                **infos_perso,
             )
         with open("templates/lm_template.html", encoding="utf-8") as f:
             lm_html = Template(f.read()).render(
@@ -536,9 +541,13 @@ def index():
             "age": age,
         }
         # --- HTML rendering
+        css_path = f"file://{Path('static/cv_theme.css').resolve()}"
         with open("templates/cv_template.html", encoding="utf-8") as f:
             cv_html = Template(f.read()).render(
-                cv=cv_adapte, infos_perso=infos_perso, **infos_perso
+                cv=cv_adapte,
+                infos_perso=infos_perso,
+                css_path=css_path,
+                **infos_perso,
             )
         with open("templates/lm_template.html", encoding="utf-8") as f:
             lm_html = Template(f.read()).render(

--- a/static/cv_theme.css
+++ b/static/cv_theme.css
@@ -1,0 +1,85 @@
+@import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Open+Sans:wght@400;600&display=swap");
+
+body {
+    font-family: 'Open Sans', Arial, sans-serif;
+    margin: 0;
+    background: #f6f7fa;
+    color: #232b35;
+}
+
+.cv-container {
+    background: #fff;
+    border-radius: 18px;
+    box-shadow: 0 6px 24px 0 #0001;
+    padding: 40px 38px;
+    max-width: 900px;
+    margin: 40px auto;
+}
+
+h1 {
+    font-family: 'Montserrat', Arial, sans-serif;
+    color: #295ddb;
+    font-size: 2.3em;
+    margin: 0 0 0.5em 0;
+}
+
+h2 {
+    font-family: 'Montserrat', Arial, sans-serif;
+    color: #4052c1;
+    font-size: 1.22em;
+    margin-top: 1.8em;
+    border-bottom: 1.5px solid #e0e5ed;
+    padding-bottom: 4px;
+    letter-spacing: 0.03em;
+}
+
+.cv-columns {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    gap: 25px;
+    margin-top: 1.2em;
+}
+
+.infos {
+    font-size: 1.05em;
+    color: #4e617d;
+    margin-bottom: 20px;
+}
+
+.infos-col {
+    margin-bottom: 4px;
+}
+
+.label {
+    font-weight: 600;
+    color: #222;
+}
+
+.section {
+    margin-top: 1.6em;
+}
+
+.tag {
+    background: #edf2ff;
+    color: #256cff;
+    padding: 2px 10px;
+    margin: 2px 8px 2px 0;
+    border-radius: 7px;
+    font-size: 1em;
+    display: inline-block;
+}
+
+ul {
+    margin: 0.6em 0 0 1.3em;
+}
+
+li {
+    margin-bottom: 4px;
+}
+
+@media (max-width: 720px) {
+    .cv-container { padding: 15px 4vw; }
+    .cv-columns { grid-template-columns: 1fr; }
+    h1 { font-size: 1.5em; }
+    h2 { font-size: 1.1em; }
+}

--- a/templates/cv_template.html
+++ b/templates/cv_template.html
@@ -3,104 +3,72 @@
 <head>
   <meta charset="UTF-8">
   <title>CV - {{ infos_perso.nom or nom }} {{ infos_perso.prenom or prenom }}</title>
-  <style>
-    body {
-      font-family: 'Segoe UI', Arial, sans-serif;
-      margin: 0;
-      background: #f6f7fa;
-      color: #232b35;
-    }
-    .cv-container {
-      background: #fff;
-      border-radius: 18px;
-      box-shadow: 0 6px 24px 0 #0001;
-      padding: 36px 38px;
-      max-width: 820px;
-      margin: 42px auto 30px auto;
-    }
-    h1 { color: #295ddb; font-size: 2.3em; margin-bottom: 0.18em; }
-    h2 { color: #4052c1; font-size: 1.22em; margin-top: 2.1em; border-bottom: 1.5px solid #e0e5ed; padding-bottom: 4px; letter-spacing: 0.03em; }
-    .infos {
-      font-size: 1.08em; color: #4e617d; margin-bottom: 17px;
-      display: flex; flex-wrap: wrap; gap: 18px 35px;
-    }
-    .infos-col {
-      min-width: 230px; margin-bottom: 3px;
-    }
-    .section { margin-top: 1.6em; }
-    .label { font-weight: bold; color: #222; }
-    .tag { background: #edf2ff; color: #256cff; padding: 2px 10px; margin: 2px 8px 2px 0; border-radius: 7px; font-size: 1em; display: inline-block; }
-    ul { margin: 0.6em 0 0 1.3em; }
-    li { margin-bottom: 4px; }
-    @media (max-width: 720px) {
-      .cv-container { padding: 15px 4vw; }
-      .infos { flex-direction: column; gap: 7px 0; }
-      h1 { font-size: 1.3em; }
-      h2 { font-size: 1.08em; }
-    }
-  </style>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ css_path }}">
 </head>
 <body>
 <div class="cv-container">
   <h1>
     {{ infos_perso.nom or nom or "Prénom" }} {{ infos_perso.prenom or prenom or "Nom" }}
   </h1>
-  <div class="infos">
-    <div class="infos-col">
-      <span class="label">Adresse :</span>
-      {{ infos_perso.adresse or adresse or "-" }}
-    </div>
-    <div class="infos-col">
-      <span class="label">Téléphone :</span>
-      {{ infos_perso.telephone or telephone or "-" }}
-    </div>
-    <div class="infos-col">
-      <span class="label">Email :</span>
-      {{ infos_perso.email or email or "-" }}
-    </div>
-    <div class="infos-col">
-      <span class="label">Âge :</span>
-      {{ infos_perso.age or age or "-" }}
-    </div>
-  </div>
   {% if cv.profil %}
   <div class="section">
     <h2>Profil professionnel</h2>
     <div>{{ cv.profil }}</div>
   </div>
   {% endif %}
-
-  {% if cv.competences %}
-  <div class="section">
-    <h2>Compétences clés</h2>
-    {% for c in cv.competences %}
-      <span class="tag">{{ c }}</span>
-    {% endfor %}
+  <div class="cv-columns">
+    <div class="cv-left">
+      <div class="infos">
+        <div class="infos-col">
+          <span class="label">Adresse :</span>
+          {{ infos_perso.adresse or adresse or "-" }}
+        </div>
+        <div class="infos-col">
+          <span class="label">Téléphone :</span>
+          {{ infos_perso.telephone or telephone or "-" }}
+        </div>
+        <div class="infos-col">
+          <span class="label">Email :</span>
+          {{ infos_perso.email or email or "-" }}
+        </div>
+        <div class="infos-col">
+          <span class="label">Âge :</span>
+          {{ infos_perso.age or age or "-" }}
+        </div>
+      </div>
+      {% if cv.competences %}
+      <div class="section">
+        <h2>Compétences clés</h2>
+        {% for c in cv.competences %}
+          <span class="tag">{{ c }}</span>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+    <div class="cv-right">
+      {% if cv.experiences %}
+      <div class="section">
+        <h2>Expériences professionnelles</h2>
+        <ul>
+          {% for e in cv.experiences %}
+            <li>{{ e }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endif %}
+      {% if cv.formations %}
+      <div class="section">
+        <h2>Formations</h2>
+        <ul>
+          {% for f in cv.formations %}
+            <li>{{ f }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endif %}
+    </div>
   </div>
-  {% endif %}
-
-  {% if cv.experiences %}
-  <div class="section">
-    <h2>Expériences professionnelles</h2>
-    <ul>
-      {% for e in cv.experiences %}
-        <li>{{ e }}</li>
-      {% endfor %}
-    </ul>
-  </div>
-  {% endif %}
-
-  {% if cv.formations %}
-  <div class="section">
-    <h2>Formations</h2>
-    <ul>
-      {% for f in cv.formations %}
-        <li>{{ f }}</li>
-      {% endfor %}
-    </ul>
-  </div>
-  {% endif %}
-
   {% if cv.autres %}
   <div class="section">
     <h2>Autres informations</h2>


### PR DESCRIPTION
## Summary
- create `cv_theme.css` with grid layout and Google fonts
- update `cv_template.html` to use new stylesheet and reorganize content
- provide CSS path when rendering templates for PDF generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for requests and pytesseract)*

------
https://chatgpt.com/codex/tasks/task_e_6840747c3ad8832494f6e9eb0afa31aa