### PR TITLE
Update photo upload message test

### DIFF
--- a/app.py
+++ b/app.py
@@ -312,7 +312,7 @@ def index():
                     tmp_photo_name = tmp_img.name
             else:
                 if PREMIUM_PHOTO_REQUIRED:
-                    error = "Une photo est requise pour le modèle premium."
+                    error = "Veuillez ajouter une photo"
                     return render_template(
                         "index.html",
                         error=error,

--- a/tests/test_app_photo.py
+++ b/tests/test_app_photo.py
@@ -1,0 +1,15 @@
+import importlib
+import shutil
+
+import pytest
+
+
+def test_photo_required(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda x: "/usr/bin/wkhtmltopdf")
+    monkeypatch.setattr("pdfkit.configuration", lambda **kw: type("Cfg", (), {"wkhtmltopdf": "/usr/bin/wkhtmltopdf"})())
+    app = importlib.import_module("app")
+    monkeypatch.setattr(app, "PREMIUM_PHOTO_REQUIRED", True)
+    client = app.app.test_client()
+    resp = client.post("/", data={"template": "premium"})
+    assert resp.status_code == 200
+    assert b"Veuillez ajouter une photo" in resp.data


### PR DESCRIPTION
## Summary
- add a new test for the premium photo upload error message
- adjust the application message when no photo is provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841356b46008324b3fb0635157d08c2