### PR TITLE
Move template selection near upload zone

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -335,6 +335,18 @@ textarea {
     min-height: 110px;
     resize: vertical;
 }
+.template-choice select {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 10px 12px;
+    margin: 7px 0 16px 0;
+    border-radius: 7px;
+    border: 1.1px solid #ced2e0;
+    font-size: 1.08em;
+    font-family: inherit;
+    background: #f9fbfd;
+}
+
 .field-row { display: flex; gap: 12px; }
 .field-row > div { flex: 1; }
 .add-btn {
@@ -458,7 +470,14 @@ body.dark-mode textarea {
     background: #1e2033;
     color: #eee;
     border-color: #44486a;
+
 }
+body.dark-mode .template-choice select {
+    background: #1e2033;
+    color: #eee;
+    border-color: #44486a;
+}
+
 body.dark-mode .label-annonce {
     background: #232642;
     color: #cad4ff !important;

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,6 +47,13 @@
                 </div>
                 <div class="upload-file-info" id="uploadedFileName" style="display:none;"></div>
             </div>
+            <div class="template-choice">
+                <label for="templateSelect">Type de CV</label>
+                <select name="template" id="templateSelect">
+                    <option value="basic" {% if template != 'premium' %}selected{% endif %}>basic</option>
+                    <option value="premium" {% if template == 'premium' %}selected{% endif %}>premium</option>
+                </select>
+            </div>
 
 
             <div class="show-manual" id="showManualBtn">
@@ -124,15 +131,6 @@
                 <button type="button" class="add-btn" onclick="addDip()">+ Ajouter un diplôme</button>
             </div>
 
-            <div class="field-row" style="margin-top:10px;">
-                <div>
-                    <label for="templateSelect">Type de CV</label>
-                    <select name="template" id="templateSelect">
-                        <option value="basic" {% if template != 'premium' %}selected{% endif %}>basic</option>
-                        <option value="premium" {% if template == 'premium' %}selected{% endif %}>premium</option>
-                    </select>
-                </div>
-            </div>
             <div id="photoZone" style="display:none; margin-bottom:12px;">
                 <label for="photo">Photo de profil</label>
                 <input type="file" name="photo" id="photoInput" accept="image/*">


### PR DESCRIPTION
## Summary
- position the CV template select next to the upload block
- style the template select like other form controls

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841435af3648324bd7775bb06be2fd9