### PR TITLE
Add photo support to DOCX CV generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,7 +201,7 @@ def generate_documents(
         options={"enable-local-file-access": ""},
     )
 
-    render_cv_docx(cv_adapte, infos_perso, cv_docx_path)
+    render_cv_docx(cv_adapte, infos_perso, cv_docx_path, photo_path)
     render_lm_docx(lettre_motivation, infos_perso, lm_docx_path)
     render_fiche_docx(fiche_poste, fiche_docx_path)
 

--- a/doc_gen.py
+++ b/doc_gen.py
@@ -1,9 +1,15 @@
 from docx import Document
+from docx.shared import Inches
 
 
-def render_cv_docx(cv, infos_perso, file_path):
+def render_cv_docx(cv, infos_perso, file_path, photo_path=None):
     doc = Document()
-    doc.add_heading(f"{infos_perso.get('prenom', '')} {infos_perso.get('nom', '')}", 0)
+    if photo_path:
+        doc.add_picture(photo_path, width=Inches(1.5))
+    doc.add_heading(
+        f"{infos_perso.get('prenom', '')} {infos_perso.get('nom', '')}",
+        0,
+    )
     doc.add_paragraph(
         f"{infos_perso.get('adresse', '')}\n"
         f"{infos_perso.get('telephone', '')} | "

--- a/tests/test_doc_gen.py
+++ b/tests/test_doc_gen.py
@@ -1,0 +1,22 @@
+import doc_gen
+
+
+def test_render_cv_docx_adds_photo(monkeypatch):
+    calls = {}
+
+    class DummyDoc:
+        def add_picture(self, path, width=None):
+            calls['path'] = path
+        def add_heading(self, *a, **k):
+            pass
+        def add_paragraph(self, *a, **k):
+            pass
+        def save(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(doc_gen, 'Document', DummyDoc)
+    monkeypatch.setattr(doc_gen, 'Inches', lambda x: x)
+
+    doc_gen.render_cv_docx({}, {'prenom': 'A', 'nom': 'B'}, 'out', photo_path='img')
+
+    assert calls['path'] == 'img'


### PR DESCRIPTION
## Summary
- insert optional photo into DOCX CVs via `render_cv_docx`
- pass uploaded photo path from `generate_documents`
- test premium photo handling includes `add_picture` call
- add direct unit test for `render_cv_docx`

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415c4000748324ac20ef59c34ff517